### PR TITLE
Location uri fix

### DIFF
--- a/frontend/controllers/shelve_it_controller.rb
+++ b/frontend/controllers/shelve_it_controller.rb
@@ -50,8 +50,11 @@ class ShelveItController < ApplicationController
     JSONModel::HTTP.get_json(path)
   end
 
+  require 'uri'
+
   def location_by_barcode(barcode)
-    path = "/locations/by_barcode/#{barcode}"
+    encoded = URI.encode_www_form_component(barcode)
+    path = "/locations/by_barcode/#{encoded}"
     JSONModel::HTTP.get_json(path)
   end
 

--- a/frontend/controllers/shelve_it_controller.rb
+++ b/frontend/controllers/shelve_it_controller.rb
@@ -50,10 +50,10 @@ class ShelveItController < ApplicationController
     JSONModel::HTTP.get_json(path)
   end
 
-  require 'uri'
+  require 'erb' # add at the top if not already present
 
   def location_by_barcode(barcode)
-    encoded = URI.encode_www_form_component(barcode)
+    encoded = ERB::Util.url_encode(barcode)
     path = "/locations/by_barcode/#{encoded}"
     JSONModel::HTTP.get_json(path)
   end


### PR DESCRIPTION
The issue reported by Ohio History Connection - location barcodes with spaces were resulting in an error
`URI::InvalidURIError (bad URI(is not URI?): “http://localhost:8089/locations/by_barcode/F03 T01 R360 V01 H01”):`
This solution converts spaces to %20 and handles other special characters. I tested this branch and it works.